### PR TITLE
Update .openpublishing.build.mdproj

### DIFF
--- a/.openpublishing.build.mdproj
+++ b/.openpublishing.build.mdproj
@@ -22,38 +22,87 @@
     <Error Condition="EXISTS('$(MSBuildThisFileDirectory)packages.config') != 'True'" Text="packages.config was not found at the expected location: $(MSBuildThisFileDirectory)." />
     <Error Condition="EXISTS('$(ToolsFolder)NuGet\NuGet.exe') != 'True'" Text="Nuget.exe was not found at the expected location: $(ToolsFolder)NuGet." />
 
-    <!-- Use NuGet to pull down any packages -->
-    <PropertyGroup>
-      <NuGetConfigFileArgument Condition="EXISTS('$(ToolsFolder)NuGet\NuGet.config') == 'True'">-ConfigFile &quot;$(ToolsFolder)NuGet\NuGet.config&quot;</NuGetConfigFileArgument>
-    </PropertyGroup>
-    <Exec Command="&quot;$(ToolsFolder)NuGet\NuGet.exe&quot; restore &quot;.\packages.config&quot; -PackagesDirectory &quot;.\packages&quot; $(NuGetConfigFileArgument)"
-          Condition="$(PackageInstalled) != 'True'"/>
-
-    <!-- Get installed package version -->
+    <!-- Get package version from packages.config -->
     <XmlPeek
         XmlInputPath=".\packages.config"
         Query="//package[@id='$(BuildTaskPackage)']/@version">
-
       <Output
           TaskParameter="Result"
           ItemName="PackageVersion" />
-
     </XmlPeek>
-
     <CreateProperty
         Value="@(PackageVersion)">
-
       <Output
           TaskParameter="Value"
           PropertyName="PackageVersion" />
-
     </CreateProperty>
+    <Message Text="Original PackageVersion=$(PackageVersion)" />
+
+    <!-- Check whether need latest package version -->
+    <PropertyGroup>
+      <UseLatestPackage>false</UseLatestPackage>
+      <UseLatestPackage Condition="'$(PackageVersion)'=='latest'">true</UseLatestPackage>
+    </PropertyGroup>
+    <Message Text="Use latest package version: $(UseLatestPackage)" />
+
+    <!-- Get Latest version from nuget server if latest version is needed -->
+    <XmlPeek
+        Condition="$(UseLatestPackage)"
+        XmlInputPath="$(ToolsFolder)NuGet\NuGet.config"
+        Query="//packageSources/add[@key='Azure']/@value">
+      <Output
+          TaskParameter="Result"
+          ItemName="NugetSource" />
+    </XmlPeek>
+    <CreateProperty
+        Condition="$(UseLatestPackage)"
+        Value="@(NugetSource)">
+      <Output
+          TaskParameter="Value"
+          PropertyName="NugetSource" />
+    </CreateProperty>
+    <Message Text="NugetSource=$(NugetSource)" Condition="$(UseLatestPackage)" />
+
+    <Exec Command="&quot;$(ToolsFolder)NuGet\NuGet.exe&quot; list $(BuildTaskPackage) -Source &quot;$(NugetSource)&quot;" ConsoleToMSBuild="true" Condition="$(UseLatestPackage)">
+      <Output TaskParameter="ConsoleOutput" PropertyName="LatestPackage" />
+    </Exec>
+    <ItemGroup Condition="$(UseLatestPackage)" >
+      <LatestPackageVersion Include="$(LatestPackage.Split(' ')[1])" />
+    </ItemGroup>
+    <CreateProperty
+        Condition="$(UseLatestPackage)"
+        Value="@(LatestPackageVersion)">
+      <Output
+          TaskParameter="Value"
+          PropertyName="LatestPackageVersion" />
+    </CreateProperty>
+    <Message Text="LatestPackageVersion=@(LatestPackageVersion)" Condition="$(UseLatestPackage)" />
+
+    <!-- Update packages.config file's version with latest version then do the restore-->
+    <XmlPoke
+       Condition="$(UseLatestPackage)"
+       XmlInputPath=".\packages.config"
+       Query="//packages/package[@id='$(BuildTaskPackage)']/@version"
+       Value="$(LatestPackageVersion)" />
+
+    <!-- Use NuGet to pull down specific version packages -->
+    <PropertyGroup>
+      <NuGetConfigFileArgument Condition="EXISTS('$(ToolsFolder)NuGet\NuGet.config') == 'True'">-ConfigFile &quot;$(ToolsFolder)NuGet\NuGet.config&quot;</NuGetConfigFileArgument>
+    </PropertyGroup>
+    <Exec Command="&quot;$(ToolsFolder)NuGet\NuGet.exe&quot; restore &quot;.\packages.config&quot; -PackagesDirectory &quot;.\packages&quot; $(NuGetConfigFileArgument)" Condition="$(PackageInstalled) != 'True'"/>
 
     <PropertyGroup>
       <BuildTaskNugetPackageFolderName>$(BuildTaskPackage).$(PackageVersion)</BuildTaskNugetPackageFolderName>
+      <BuildTaskNugetPackageFolderName Condition="$(UseLatestPackage)">$(BuildTaskPackage).$(LatestPackageVersion)</BuildTaskNugetPackageFolderName>
       <PackageRootFolder>$(MSBuildThisFileDirectory)packages\$(BuildTaskNugetPackageFolderName)\</PackageRootFolder>
     </PropertyGroup>
 
+    <!-- Update packages.config file's version back to "latest" string-->
+    <XmlPoke
+       Condition="$(UseLatestPackage)"
+       XmlInputPath=".\packages.config"
+       Query="//packages/package[@id='$(BuildTaskPackage)']/@version"
+       Value="$(PackageVersion)" />
   </Target>
 
   <!-- Build Target -->

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages> 
-  <package id="OpenPublishingBuild" version="1.0.0" targetFramework="net45" />
+  <package id="OpenPublishingBuild" version="latest" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
After check in this file.
If user write "latest" string as version number in packages.config. Then system will always use latest version to do build. Otherwise, it will use the version specific to do build such as 1.0.0